### PR TITLE
#minor [bug fix] Google colab ray version and link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [![Documentation Status](https://readthedocs.org/projects/marllib/badge/?version=latest)](https://marllib.readthedocs.io/en/latest/)
 [![GitHub issues](https://img.shields.io/github/issues/Replicable-MARL/MARLlib)](https://github.com/Replicable-MARL/MARLlib/issues)
 [![PyPI version](https://badge.fury.io/py/marllib.svg)](https://badge.fury.io/py/marllib)
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Replicable-MARL/MARLlib/blob/rllib_1.8.0_dev/marllib.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Replicable-MARL/MARLlib/blob/master/marllib.ipynb)
 [![Organization](https://img.shields.io/badge/Organization-ReLER_RL-blue.svg)](https://github.com/Replicable-MARL/MARLlib)
 [![Organization](https://img.shields.io/badge/Organization-PKU_MARL-blue.svg)](https://github.com/Replicable-MARL/MARLlib)
 [![Awesome](https://awesome.re/badge.svg)](https://marllib.readthedocs.io/en/latest/resources/awesome.html)
@@ -359,7 +359,7 @@ MARLlib provides some practical examples for you to refer to.
 ## Tutorials
 
 Try MPE + MAPPO examples on Google Colaboratory!
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Replicable-MARL/MARLlib/blob/rllib_1.8.0_dev/marllib.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Replicable-MARL/MARLlib/blob/master/marllib.ipynb)
 More tutorial documentations are available [here](https://marllib.readthedocs.io/).
 
 ## Awesome List

--- a/marllib.ipynb
+++ b/marllib.ipynb
@@ -50,7 +50,7 @@
    },
    "outputs": [],
    "source": [
-    "!/usr/local/bin/pip install protobuf==3.20.0 marllib==1.0.3 ray[rllib] gym==0.22.0"
+    "!/usr/local/bin/pip install protobuf==3.20.0 marllib==1.0.3 ray[rllib]==1.8.0 gym==0.22.0"
    ]
   },
   {


### PR DESCRIPTION
In the old Colab the rllib version isnot explicitly set so the environment gets ray 2.6.1 rather than the supported 1.8 version. Also, the link from the readme leads to the ipynb version in the dev branch rather than the master.