### PR TITLE
[bug fix] added num_gpus variable to ray init call

### DIFF
--- a/marllib/marl/algos/run_cc.py
+++ b/marllib/marl/algos/run_cc.py
@@ -59,7 +59,7 @@ def restore_config_update(exp_info, run_config, stop_config):
 
 
 def run_cc(exp_info, env, model, stop=None):
-    ray.init(local_mode=exp_info["local_mode"])
+    ray.init(local_mode=exp_info["local_mode"], num_gpus=exp_info["num_gpus"])
 
     ########################
     ### environment info ###

--- a/marllib/marl/algos/run_il.py
+++ b/marllib/marl/algos/run_il.py
@@ -34,7 +34,7 @@ torch, nn = try_import_torch()
 
 
 def run_il(exp_info, env, model, stop=None):
-    ray.init(local_mode=exp_info["local_mode"])
+    ray.init(local_mode=exp_info["local_mode"], num_gpus=exp_info["num_gpus"])
 
     ########################
     ### environment info ###

--- a/marllib/marl/algos/run_vd.py
+++ b/marllib/marl/algos/run_vd.py
@@ -36,7 +36,7 @@ torch, nn = try_import_torch()
 
 
 def run_vd(exp_info, env, model, stop=None):
-    ray.init(local_mode=exp_info["local_mode"])
+    ray.init(local_mode=exp_info["local_mode"], num_gpus=exp_info["num_gpus"])
 
     ########################
     ### environment info ###


### PR DESCRIPTION
To use my GPU (with the devcontainer setup) I needed to add the `num_gpus` variable to the `ray.init()` call.

**Bug behavior**
Whenever I set `num_gpus` > 1, I got a Ray error stating that no nodes/resources were available that fit my request. After the proposed changes, this error did not occur anymore.

**Beware**
If Ray auto-detected the GPUs available on your server before, this probably shouldn't interfere with this auto-detection. But I don't have the setup to test this. So please try if your GPUs are still autodetected with the proposed changes - in case you used GPUs.

**For the future**
Maybe there should be additional tests for `num_gpus` > 1 behavior. However, they obviously only make sense for a setup that has GPUs.