### PR TITLE
Return results when the algorithms finish

### DIFF
--- a/marllib/marl/__init__.py
+++ b/marllib/marl/__init__.py
@@ -309,11 +309,11 @@ class _Algo:
         self.config_dict['algorithm'] = self.name
 
         if self.algo_type == "IL":
-            run_il(self.config_dict, env_instance, model_class, stop=stop)
+            return run_il(self.config_dict, env_instance, model_class, stop=stop)
         elif self.algo_type == "VD":
-            run_vd(self.config_dict, env_instance, model_class, stop=stop)
+            return run_vd(self.config_dict, env_instance, model_class, stop=stop)
         elif self.algo_type == "CC":
-            run_cc(self.config_dict, env_instance, model_class, stop=stop)
+            return run_cc(self.config_dict, env_instance, model_class, stop=stop)
         else:
             raise ValueError("not supported type {}".format(self.algo_type))
 

--- a/marllib/marl/algos/run_cc.py
+++ b/marllib/marl/algos/run_cc.py
@@ -195,3 +195,5 @@ def run_cc(exp_info, env, model, stop=None):
                                                      restore_config)
 
     ray.shutdown()
+
+    return results

--- a/marllib/marl/algos/run_il.py
+++ b/marllib/marl/algos/run_il.py
@@ -153,3 +153,6 @@ def run_il(exp_info, env, model, stop=None):
     results = POlICY_REGISTRY[exp_info["algorithm"]](model, exp_info, run_config, env_info, stop_config,
                                                      restore_config)
     ray.shutdown()
+
+    return results
+

--- a/marllib/marl/algos/run_vd.py
+++ b/marllib/marl/algos/run_vd.py
@@ -208,3 +208,6 @@ def run_vd(exp_info, env, model, stop=None):
     results = POlICY_REGISTRY[exp_info["algorithm"]](model, exp_info, run_config, env_info, stop_config,
                                                      restore_config)
     ray.shutdown()
+
+    return results
+


### PR DESCRIPTION
I have made some minor adjustments to the existing code. These changes do not alter any current logic or produce any side effects. The only purpose of these modifications is to allow `run_cc.py`, as well as run_il and run_vd, to return the `results` after the algorithm's execution.
The returning results provides users with additional information like:
1. log directory: `results.trials[0].logdir`
2. best checkpoint directory: `results._checkpoints[0]['checkpoint_manager']._best_checkpoints[0].value.value`
3. newest checkpoint directory: `results._checkpoints[0]['checkpoint_manager'].newest_checkpoint.value`
4. and etc.