### PR TITLE
Update/FIX requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+setuptools==65.5.0
+pip==21
+wheel==0.38.0
+protobuf==3.20.3
 ray==1.8.0
 ray[tune]==1.8.0
 ray[rllib]==1.8.0


### PR DESCRIPTION
Greetings.
Due to  upgrading packages and systems, some packages doesn't  work and broke whole process.
following packages have been added to `requirements.txt` which were last version who work with other packages(gym was major issue.).

ps. personal experience: i would rather make a **EXCLUSIVE  file** just for `pip-setuptools-wheel` as they have higher priority to install. But to maintain the structure of the files, I put them next to the other packages.

protobuf =>  last working version with whole env

pip-setuptools-wheel => Last working version with Gym